### PR TITLE
To fix disappearing parameters on system flush

### DIFF
--- a/api/v3/PDFbundle/Sendpdf.mgd.php
+++ b/api/v3/PDFbundle/Sendpdf.mgd.php
@@ -2,14 +2,15 @@
 // This file declares a managed database record of type "Job".
 // The record will be automatically inserted, updated, or deleted from the
 // database as appropriate. For more details, see "hook_civicrm_managed" at:
-// http://wiki.civicrm.org/confluence/display/CRMDOC42/Hook+Reference
-return array (
-  0 => 
-  array (
+// https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed/
+return [
+  0 => [
     'name' => 'Cron:PDFbundle.Sendpdf',
     'entity' => 'Job',
-    'params' => 
-    array (
+    // This job requires the admin to set various params in the Scheduled Job
+    // settings. Without update=never those params will be lost on system.flush.
+    'update' => 'never',
+    'params' => [
       'version' => 3,
       'name' => 'Create 1 bundled PDF for entire group, email to staff/volunteer contact',
       'description' => 'Sends a single large PDF to the contact specified, who will presumably print and mail it via snail mail.',
@@ -17,6 +18,6 @@ return array (
       'api_entity' => 'PDFbundle',
       'api_action' => 'Sendpdf',
       'parameters' => '',
-    ),
-  ),
-);
+    ],
+  ],
+];


### PR DESCRIPTION
@sgladstone I simply copied that which @mlutfy did on the previous PR but for PDFbundle